### PR TITLE
fix: always convert json payloads to ascii

### DIFF
--- a/restapi.py
+++ b/restapi.py
@@ -85,7 +85,7 @@ class Endpoint(object):
 
     def post(self, user_data, the_id=None, user_params={}, user_headers={}):
 
-        strjsondata = ujson.dumps(user_data, ensure_ascii=False)
+        strjsondata = ujson.dumps(user_data, ensure_ascii=True)
 
         if the_id:
             url = self._url(self.endpoint, the_id)
@@ -111,7 +111,7 @@ class Endpoint(object):
 
     def put(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = ujson.dumps(user_data, ensure_ascii=False)
+        strjsondata = ujson.dumps(user_data, ensure_ascii=True)
 
         resp = req.put(
             self._url(self.endpoint, the_id),
@@ -131,7 +131,7 @@ class Endpoint(object):
 
     def patch(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = ujson.dumps(user_data, ensure_ascii=False)
+        strjsondata = ujson.dumps(user_data, ensure_ascii=True)
 
         resp = req.patch(
             self._url(self.endpoint, the_id),


### PR DESCRIPTION
The POST, PUT and PATCH methods do not convert all payloads to ASCII as `ensure_ascii=False` is set on the calls to `json.dumps()`.

Currently, if you to send a POST or PATCH request that contains UTF-8 characters to the ConnectWise API, you receive an error.

e.g.

```python
>>> data = [{"op": "replace", "path": "firstName", "value": "Liám"}]
>>> payload = json.dumps(
...   data, ensure_ascii=False # current connectpyse behaviour
... )
>>> response = requests.request("PATCH", url, headers=headers, data=payload)
>>> response.raise_for_status()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".venv/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://redacted/v4_6_release/apis/3.0/company/contacts/5651
>>> response.json()
{'code': 'ConnectWiseApi', 'message': 'The JSON input is not in the expected array format for a JSON Patch document. A JSON Patch document should be a JSON array of patch operations. Please revise your JSON structure and try again.'}
```

If you set `ensure_ascii=True`, which is the default of `json.dumps()`, the request is accepted:

```python
>>> payload = json.dumps(
...   data, ensure_ascii=True # default json behaviour
... )
>>>
>>> response = requests.request("PATCH", url, headers=headers, data=payload)
>>> response.raise_for_status()
>>> response.status_code
200
```

This PR replaces all usage of `ensure_ascii=False` with `ensure_ascii=True`. 

I'm happy to flesh this out a bit more if you want this setting to be controlled by the user.

Note that I am testing against an on-prem instance of ConnectWise (v2024.6.100619).